### PR TITLE
add customizable output data directory

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -75,11 +75,7 @@ class Crawler
         $this->limit = $limit;
         $this->wait = $waitInMicroSeconds;
 
-        if (null === $dataDirectoryBasePath) {
-            $this->dataDirectoryBasePath = __DIR__.'/../data';
-        } else {
-            $this->dataDirectoryBasePath = rtrim($dataDirectoryBasePath, '/');
-        }
+        $this->initDataDirectory($dataDirectoryBasePath);
 
         $this->recorder = new Recorder($this->getDataFolder(), $cacheMethod);
 
@@ -92,6 +88,14 @@ class Crawler
             'cacheMethod' => $cacheMethod,
             'wait' => $waitInMicroSeconds,
         ]));
+    }
+
+    /**
+     * @param string $dataDirectoryBasePath
+     */
+    protected function initDataDirectory(string $dataDirectoryBasePath = null)
+    {
+        $this->dataDirectoryBasePath = rtrim($dataDirectoryBasePath ?? __DIR__.'/../data', '/');
     }
 
     public function getId()

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -42,6 +42,11 @@ class Crawler
      */
     protected $fromCache;
 
+    /**
+     * @var string
+     */
+    protected $dataDirectoryBasePath;
+
     protected $recorder;
     protected $robotsTxt;
     protected $request;
@@ -59,7 +64,8 @@ class Crawler
         int $limit,
         string $userAgent,
         int $cacheMethod = Recorder::CACHE_ID,
-        int $waitInMicroSeconds = 100000
+        int $waitInMicroSeconds = 100000,
+        string $dataDirectoryBasePath = null
     ) {
         $startUrl = $this->setBaseAndReturnNormalizedStartUrl($startUrl);
         $this->urls[$startUrl] = null;
@@ -68,6 +74,12 @@ class Crawler
         $this->userAgent = $userAgent;
         $this->limit = $limit;
         $this->wait = $waitInMicroSeconds;
+
+        if (null === $dataDirectoryBasePath) {
+            $this->dataDirectoryBasePath = __DIR__.'/../data';
+        } else {
+            $this->dataDirectoryBasePath = rtrim($dataDirectoryBasePath, '/');
+        }
 
         $this->recorder = new Recorder($this->getDataFolder(), $cacheMethod);
 
@@ -101,7 +113,7 @@ class Crawler
 
     public function getDataFolder()
     {
-        return __DIR__.'/../data/'.$this->id;
+        return $this->dataDirectoryBasePath.'/'.$this->id;
     }
 
     public function crawl(bool $debug = false)

--- a/src/CrawlerContinue.php
+++ b/src/CrawlerContinue.php
@@ -7,9 +7,10 @@ use League\Csv\Reader;
 
 class CrawlerContinue extends Crawler
 {
-    public function __construct(string $id)
+    public function __construct(string $id, string $dataDirectoryBasePath = null)
     {
         $this->id = trim($id);
+        $this->initDataDirectory($dataDirectoryBasePath);
 
         $configFilePath = $this->getDataFolder().'/config.json';
         if (!file_exists($configFilePath)) {

--- a/src/CrawlerRestart.php
+++ b/src/CrawlerRestart.php
@@ -7,11 +7,11 @@ use PiedWeb\Curl\ResponseFromCache;
 
 class CrawlerRestart extends CrawlerContinue
 {
-    public function __construct(string $id, bool $fromCache = false)
+    public function __construct(string $id, bool $fromCache = false, string $dataDirectoryBasePath = null)
     {
         $this->fromCache = $fromCache;
 
-        parent::__construct($id);
+        parent::__construct($id,$dataDirectoryBasePath);
 
         $this->resetLinks();
     }


### PR DESCRIPTION
Hey @RobinDev 

this patch allow to customize the data directory path which is a mandatory feature for using the crawler without the binary as a pure PHP dependancy 